### PR TITLE
add: 키워드 배치 분석기 및 대시보드 추가

### DIFF
--- a/components/keyword_analyzer.py
+++ b/components/keyword_analyzer.py
@@ -1,0 +1,171 @@
+"""키워드 배치 분석기.
+
+chat_messages 테이블에서 미분석 메시지가 임계값 이상 쌓이면
+키워드 분석을 실행하여 keyword_counts에 저장한다.
+
+추적 기준: created_at (DB 삽입 시각) — msg_id는 해시이므로 순서 비교 불가.
+"""
+
+import time
+from collections import defaultdict
+
+from kiwipiepy import Kiwi
+from psycopg2.extras import execute_values
+
+from modules.postgresql import get_connection
+
+POLL_INTERVAL = 10  # DB 폴링 주기 (초)
+
+TARGET_POS = {"NNG", "NNP", "VV", "VA"}
+TARGET_MSG_TYPES = ("CHAT", "DONATION")
+MIN_KEYWORD_LEN = 2
+
+UPSERT_KEYWORD_SQL = """
+    INSERT INTO keyword_counts (window_start, streamer, keyword, pos, count)
+    VALUES %s
+    ON CONFLICT (window_start, streamer, keyword, pos)
+    DO UPDATE SET count = keyword_counts.count + EXCLUDED.count
+"""
+
+kiwi = Kiwi()
+
+def _get_setting(conn, key: str) -> str:
+    with conn.cursor() as cur:
+        cur.execute("SELECT value FROM keyword_settings WHERE key = %s", (key,))
+        row = cur.fetchone()
+        return row[0] if row else ""
+
+
+def _set_setting(conn, key: str, value: str):
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO keyword_settings (key, value) VALUES (%s, %s) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+            (key, value),
+        )
+    conn.commit()
+
+
+def _count_unanalyzed(conn, last_at: str) -> int:
+    """미분석 메시지 수를 반환한다."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM chat_messages "
+            "WHERE created_at > %s::timestamp AND msg_type IN %s",
+            (last_at, TARGET_MSG_TYPES),
+        )
+        return cur.fetchone()[0]
+
+
+def _fetch_batch(conn, last_at: str) -> list[dict]:
+    """미분석 메시지를 전부 가져온다 (created_at 순)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT created_at, ts, streamer, message FROM chat_messages "
+            "WHERE created_at > %s::timestamp AND msg_type IN %s "
+            "ORDER BY created_at",
+            (last_at, TARGET_MSG_TYPES),
+        )
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def extract_keywords(text: str) -> list[tuple[str, str]]:
+    """텍스트에서 명사/동사/형용사를 추출한다."""
+    tokens = kiwi.tokenize(text)
+    return [
+        (t.form, t.tag)
+        for t in tokens
+        if t.tag in TARGET_POS and len(t.form) >= MIN_KEYWORD_LEN
+    ]
+
+
+def extract_bigrams(text: str) -> list[tuple[str, str]]:
+    """텍스트에서 명사 바이그램을 추출한다.
+
+    연속된 명사 2개를 결합하여 복합 키워드로 만든다.
+    예: "롤 챔피언" → ("롤 챔피언", "BIGRAM")
+    """
+    tokens = kiwi.tokenize(text)
+    nouns = [
+        t for t in tokens
+        if t.tag in ("NNG", "NNP") and len(t.form) >= MIN_KEYWORD_LEN
+    ]
+    bigrams = []
+    for i in range(len(nouns) - 1):
+        # 원문에서 연속된 위치인지 확인 (사이 간격 3자 이하)
+        if nouns[i + 1].start - nouns[i].end <= 3:
+            combined = f"{nouns[i].form} {nouns[i + 1].form}"
+            bigrams.append((combined, "BIGRAM"))
+    return bigrams
+
+
+def _analyze_batch(conn, messages: list[dict]):
+    """메시지 배치를 분석하여 keyword_counts에 upsert한다."""
+    counts: dict[tuple, int] = defaultdict(int)
+
+    for msg in messages:
+        text = msg["message"]
+        if not text:
+            continue
+
+        streamer = msg["streamer"]
+        # 1분 단위 윈도우
+        window_start = msg["ts"].replace(second=0, microsecond=0)
+
+        # 단일 키워드
+        for keyword, pos in extract_keywords(text):
+            counts[(window_start, streamer, keyword, pos)] += 1
+
+        # 바이그램
+        for bigram, pos in extract_bigrams(text):
+            counts[(window_start, streamer, bigram, pos)] += 1
+
+    if not counts:
+        return
+
+    values = [
+        (window_start, streamer, keyword, pos, cnt)
+        for (window_start, streamer, keyword, pos), cnt in counts.items()
+    ]
+    with conn.cursor() as cur:
+        execute_values(cur, UPSERT_KEYWORD_SQL, values)
+    conn.commit()
+
+    print(f"  [KeywordAnalyzer] {len(messages)}건 분석 → {len(values)}개 키워드 집계 upsert")
+
+
+def run():
+    conn = get_connection()
+    conn.autocommit = False
+
+    print("[KeywordAnalyzer] 시작됨. 미분석 채팅 폴링 중...")
+
+    while True:
+        try:
+            last_at = _get_setting(conn, "last_analyzed_at") or "1970-01-01T00:00:00"
+            threshold = int(_get_setting(conn, "chat_threshold") or "500")
+
+            pending = _count_unanalyzed(conn, last_at)
+
+            if pending >= threshold:
+                print(f"[KeywordAnalyzer] 미분석 {pending}건 >= 임계값 {threshold} → 분석 시작")
+
+                messages = _fetch_batch(conn, last_at)
+                if messages:
+                    _analyze_batch(conn, messages)
+                    new_last_at = messages[-1]["created_at"].isoformat()
+                    _set_setting(conn, "last_analyzed_at", new_last_at)
+                    print("[KeywordAnalyzer] 분석 완료. last_analyzed_at 갱신")
+
+        except Exception as e:
+            print(f"[KeywordAnalyzer] 오류: {e}")
+            try:
+                conn.rollback()
+                conn.close()
+            except Exception:
+                pass
+            conn = get_connection()
+            conn.autocommit = False
+
+        time.sleep(POLL_INTERVAL)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -64,13 +64,15 @@ st.markdown("<br>", unsafe_allow_html=True)
 # --- 네비게이션 ---
 section_title("바로가기")
 
-col1, col2, col3, col4 = st.columns(4)
+col1, col2, col3, col4, col5 = st.columns(5)
 
 with col1:
-    st.page_link("pages/1_streamers.py", label="📡  스트리머 관리", use_container_width=True)
+    st.page_link("pages/1_streamers.py", label="📡  스트리머 관리", width="stretch")
 with col2:
-    st.page_link("pages/2_stats.py", label="📈  수집 통계", use_container_width=True)
+    st.page_link("pages/2_stats.py", label="📈  수집 통계", width="stretch")
 with col3:
-    st.page_link("pages/3_database.py", label="🗄️  데이터베이스", use_container_width=True)
+    st.page_link("pages/3_database.py", label="🗄️  데이터베이스", width="stretch")
 with col4:
-    st.page_link("pages/4_kafka.py", label="⚡  Kafka", use_container_width=True)
+    st.page_link("pages/4_kafka.py", label="⚡  Kafka", width="stretch")
+with col5:
+    st.page_link("pages/5_keywords.py", label="🔤  키워드 분석", width="stretch")

--- a/dashboard/pages/1_streamers.py
+++ b/dashboard/pages/1_streamers.py
@@ -35,7 +35,7 @@ with col_input:
         label_visibility="collapsed",
     )
 with col_btn:
-    add_clicked = st.button("등록", use_container_width=True, type="primary")
+    add_clicked = st.button("등록", width="stretch", type="primary")
 
 if add_clicked and input_url:
     streamer_id = input_url.strip().rstrip("/").split("/")[-1]

--- a/dashboard/pages/2_stats.py
+++ b/dashboard/pages/2_stats.py
@@ -134,7 +134,7 @@ def render_stats():
         )
         tab1, tab2 = st.tabs(["테이블", "차트"])
         with tab1:
-            st.dataframe(pivot, use_container_width=True)
+            st.dataframe(pivot, width="stretch")
         with tab2:
             st.bar_chart(pivot)
     else:

--- a/dashboard/pages/3_database.py
+++ b/dashboard/pages/3_database.py
@@ -115,7 +115,7 @@ with tab_single:
             label_visibility="collapsed",
         )
     with col_del:
-        if st.button("삭제", key="btn_del_single", use_container_width=True):
+        if st.button("삭제", key="btn_del_single", width="stretch"):
             if msg_id_to_delete:
                 pk_col = "streamer_id" if table == "streamers" else "msg_id"
                 with conn.cursor() as cur:
@@ -180,7 +180,7 @@ sql_input = st.text_area(
 
 col_sql1, col_sql2 = st.columns([1, 7])
 with col_sql1:
-    run_sql = st.button("실행", type="primary", use_container_width=True)
+    run_sql = st.button("실행", type="primary", width="stretch")
 
 if run_sql and sql_input:
     try:

--- a/dashboard/pages/5_keywords.py
+++ b/dashboard/pages/5_keywords.py
@@ -1,0 +1,367 @@
+"""키워드 분석"""
+
+import base64
+import html
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from modules.postgresql import get_connection
+from dashboard.style import apply_style, metric_card, section_title
+
+EMOJI_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "emojis"
+EMOJI_TAG_RE = re.compile(r"\[emoji:([a-zA-Z0-9_]+):([^\]]+)\]")
+
+_b64_cache: dict[str, str] = {}
+
+
+def _emoji_to_b64(filename: str) -> str | None:
+    if filename in _b64_cache:
+        return _b64_cache[filename]
+    path = EMOJI_DIR / filename
+    if not path.exists():
+        return None
+    data = base64.b64encode(path.read_bytes()).decode()
+    ext = filename.rsplit(".", 1)[-1]
+    mime = "image/png" if ext == "png" else f"image/{ext}"
+    result = f"data:{mime};base64,{data}"
+    _b64_cache[filename] = result
+    return result
+
+
+def render_message(text: str) -> str:
+    if not text:
+        return ""
+    escaped = html.escape(text)
+
+    def _replace(m):
+        filename = m.group(2)
+        b64 = _emoji_to_b64(filename)
+        if b64:
+            return (f'<img src="{b64}" alt="{m.group(1)}" '
+                    'style="height:1.5em; vertical-align:middle; margin:0 2px;">')
+        return f"[{m.group(1)}]"
+
+    return EMOJI_TAG_RE.sub(_replace, escaped)
+
+
+def query_df(conn, sql, params=None):
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        if cur.description is None:
+            return pd.DataFrame()
+        cols = [desc[0] for desc in cur.description]
+        return pd.DataFrame(cur.fetchall(), columns=cols)
+
+
+def _get_setting(conn, key: str) -> str:
+    with conn.cursor() as cur:
+        cur.execute("SELECT value FROM keyword_settings WHERE key = %s", (key,))
+        row = cur.fetchone()
+        return row[0] if row else ""
+
+
+def _set_setting(conn, key: str, value: str):
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO keyword_settings (key, value) VALUES (%s, %s) "
+            "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+            (key, value),
+        )
+    conn.commit()
+
+
+st.set_page_config(page_title="키워드 분석", page_icon="🔤", layout="wide")
+apply_style()
+
+st.markdown("""
+<h1 style="font-weight: 800; margin-bottom: 0.2rem;">🔤 키워드 분석</h1>
+<p style="color: #6b7280; margin-bottom: 1.5rem;">채팅 키워드 빈도 분석 (배치 집계)</p>
+""", unsafe_allow_html=True)
+
+
+# --- 분석 설정 ---
+section_title("분석 설정")
+
+settings_conn = get_connection()
+
+current_threshold = int(_get_setting(settings_conn, "chat_threshold") or "500")
+
+new_threshold = st.number_input(
+    "분석 트리거 임계값 (채팅 수)",
+    min_value=50,
+    max_value=100000,
+    value=current_threshold,
+    step=50,
+    help="미분석 채팅이 이 수 이상 쌓이면 자동으로 키워드 분석을 실행합니다.",
+)
+if new_threshold != current_threshold:
+    _set_setting(settings_conn, "chat_threshold", str(new_threshold))
+    st.success(f"임계값이 {new_threshold}으로 변경되었습니다.")
+
+settings_conn.close()
+
+
+@st.fragment(run_every=5)
+def render_pending():
+    _conn = get_connection()
+    last_at = _get_setting(_conn, "last_analyzed_at") or "1970-01-01T00:00:00"
+    threshold_val = int(_get_setting(_conn, "chat_threshold") or "500")
+
+    with _conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM chat_messages "
+            "WHERE created_at > %s::timestamp AND msg_type IN ('CHAT', 'DONATION')",
+            (last_at,),
+        )
+        pending_count = cur.fetchone()[0]
+    _conn.close()
+
+    progress = min(pending_count / threshold_val, 1.0) if threshold_val > 0 else 0
+    st.markdown(f"**미분석 채팅**: {pending_count:,}건 / 임계값 {threshold_val:,}건")
+    st.progress(progress)
+    if pending_count >= threshold_val:
+        st.success("임계값 도달 — 다음 폴링 시 분석이 실행됩니다.")
+    else:
+        remaining = threshold_val - pending_count
+        st.info(f"분석까지 {remaining:,}건 남음")
+
+
+render_pending()
+
+
+# --- 필터 ---
+section_title("필터")
+
+conn = get_connection()
+
+with conn.cursor() as cur:
+    cur.execute("SELECT DISTINCT streamer FROM keyword_counts ORDER BY streamer")
+    streamer_list = [row[0] for row in cur.fetchall()]
+
+col_f1, col_f2, col_f3 = st.columns(3)
+
+with col_f1:
+    selected_streamer = st.selectbox("스트리머", options=["전체"] + streamer_list, index=0)
+
+with col_f2:
+    pos_options = {"전체": None, "명사 (NNG)": "NNG", "고유명사 (NNP)": "NNP",
+                   "동사 (VV)": "VV", "형용사 (VA)": "VA", "바이그램": "BIGRAM"}
+    selected_pos_label = st.selectbox("품사", options=list(pos_options.keys()), index=0)
+    selected_pos = pos_options[selected_pos_label]
+
+with col_f3:
+    time_range = st.selectbox("시간 범위", options=["최근 1시간", "최근 6시간", "최근 24시간", "전체"], index=0)
+    time_interval_map = {"최근 1시간": "1 hour", "최근 6시간": "6 hours", "최근 24시간": "24 hours", "전체": None}
+    time_interval = time_interval_map[time_range]
+
+# keyword_counts 필터
+where_clauses = []
+params = []
+
+if selected_streamer != "전체":
+    where_clauses.append("streamer = %s")
+    params.append(selected_streamer)
+if selected_pos:
+    where_clauses.append("pos = %s")
+    params.append(selected_pos)
+if time_interval:
+    where_clauses.append("window_start >= NOW() - INTERVAL %s")
+    params.append(time_interval)
+
+where_sql = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+
+# chat_messages 필터
+chat_where_clauses = ["msg_type IN ('CHAT', 'DONATION')"]
+chat_params = []
+
+if selected_streamer != "전체":
+    chat_where_clauses.append("streamer = %s")
+    chat_params.append(selected_streamer)
+if time_interval:
+    chat_where_clauses.append("ts >= NOW() - INTERVAL %s")
+    chat_params.append(time_interval)
+
+chat_where_sql = "WHERE " + " AND ".join(chat_where_clauses)
+
+
+# --- 실시간 갱신 영역 ---
+@st.fragment(run_every=5)
+def render_keywords():
+    _conn = get_connection()
+
+    # 요약 메트릭
+    summary = query_df(_conn, f"""
+        SELECT
+            COUNT(DISTINCT keyword) as unique_keywords,
+            COALESCE(SUM(count), 0) as total_count,
+            COUNT(DISTINCT window_start) as window_count
+        FROM keyword_counts {where_sql}
+    """, params or None)
+
+    if not summary.empty:
+        row = summary.iloc[0]
+        c1, c2, c3 = st.columns(3)
+        with c1:
+            metric_card("고유 키워드", f"{int(row['unique_keywords']):,}개")
+        with c2:
+            metric_card("총 출현 횟수", f"{int(row['total_count']):,}회", "green")
+        with c3:
+            metric_card("집계 윈도우", f"{int(row['window_count']):,}개", "orange")
+
+    st.markdown("<br>", unsafe_allow_html=True)
+
+    # TOP 20 키워드
+    section_title("인기 키워드 TOP 20")
+
+    df_top = query_df(_conn, f"""
+        SELECT keyword, pos, SUM(count) as total
+        FROM keyword_counts {where_sql}
+        GROUP BY keyword, pos
+        ORDER BY total DESC
+        LIMIT 20
+    """, params or None)
+
+    if not df_top.empty:
+        tab1, tab2 = st.tabs(["차트", "테이블"])
+        with tab1:
+            chart_df = df_top.set_index("keyword")
+            st.bar_chart(chart_df["total"])
+        with tab2:
+            pos_labels = {"NNG": "일반명사", "NNP": "고유명사", "VV": "동사",
+                          "VA": "형용사", "BIGRAM": "바이그램"}
+            display_df = df_top.copy()
+            display_df["pos"] = display_df["pos"].map(lambda x: pos_labels.get(x, x))
+            display_df.columns = ["키워드", "품사", "출현 횟수"]
+            st.dataframe(display_df, width="stretch", hide_index=True)
+    else:
+        st.info("키워드 데이터가 없습니다.")
+
+    # 키워드가 포함된 원본 채팅 (문장 단위)
+    section_title("최근 채팅 (키워드 포함)")
+
+    keyword_search = st.text_input(
+        "키워드 검색",
+        placeholder="특정 키워드로 채팅 필터링 (비우면 최신 채팅 표시)",
+    )
+
+    search_clauses = list(chat_where_clauses)
+    search_params = list(chat_params)
+    if keyword_search:
+        search_clauses.append("message ILIKE %s")
+        search_params.append(f"%{keyword_search}%")
+    search_where = "WHERE " + " AND ".join(search_clauses)
+
+    df_messages = query_df(_conn, f"""
+        SELECT ts, streamer, nickname, message, msg_type
+        FROM chat_messages {search_where}
+        ORDER BY ts DESC
+        LIMIT 50
+    """, search_params or None)
+
+    if not df_messages.empty:
+        chat_html_parts = []
+        for _, row in df_messages.iterrows():
+            ts_str = row["ts"].strftime("%H:%M:%S")
+            nickname = html.escape(str(row["nickname"] or ""))
+            msg_html = render_message(row["message"] or "")
+            type_badge = ""
+            if row["msg_type"] == "DONATION":
+                type_badge = '<span style="background:#f5576c; color:white; padding:1px 6px; border-radius:8px; font-size:0.75rem; margin-right:4px;">후원</span>'
+
+            chat_html_parts.append(
+                f'<div style="padding:6px 0; border-bottom:1px solid #f3f4f6;">'
+                f'<span style="color:#9ca3af; font-size:0.8rem; margin-right:8px;">{ts_str}</span>'
+                f'{type_badge}'
+                f'<span style="font-weight:600; margin-right:6px;">{nickname}</span>'
+                f'<span>{msg_html}</span>'
+                f'</div>'
+            )
+
+        st.markdown(
+            '<div style="max-height:400px; overflow-y:auto; border:1px solid #e5e7eb; border-radius:8px; padding:8px 12px;">'
+            + "".join(chat_html_parts)
+            + '</div>',
+            unsafe_allow_html=True,
+        )
+    else:
+        st.info("해당 조건의 채팅 데이터가 없습니다.")
+
+    # 키워드 트렌드 (시간별 추이)
+    section_title("키워드 트렌드")
+
+    df_trend = query_df(_conn, f"""
+        SELECT window_start, keyword, SUM(count) as total
+        FROM keyword_counts {where_sql}
+        GROUP BY window_start, keyword
+        ORDER BY window_start
+    """, params or None)
+
+    if not df_trend.empty:
+        top5 = df_trend.groupby("keyword")["total"].sum().nlargest(5).index.tolist()
+        df_trend_top = df_trend[df_trend["keyword"].isin(top5)]
+        pivot_trend = df_trend_top.pivot_table(
+            index="window_start", columns="keyword", values="total", fill_value=0, aggfunc="sum"
+        )
+        st.line_chart(pivot_trend)
+    else:
+        st.info("트렌드 데이터가 없습니다.")
+
+    # 품사별 비율
+    section_title("품사별 분포")
+
+    df_pos = query_df(_conn, f"""
+        SELECT pos, SUM(count) as total
+        FROM keyword_counts {where_sql}
+        GROUP BY pos
+        ORDER BY total DESC
+    """, params or None)
+
+    if not df_pos.empty:
+        pos_labels = {"NNG": "일반명사", "NNP": "고유명사", "VV": "동사",
+                      "VA": "형용사", "BIGRAM": "바이그램"}
+        df_pos["품사명"] = df_pos["pos"].map(lambda x: pos_labels.get(x, x))
+        chart_df = df_pos.set_index("품사명")
+        st.bar_chart(chart_df["total"])
+    else:
+        st.info("품사 데이터가 없습니다.")
+
+    # 스트리머별 키워드 비교
+    if selected_streamer == "전체" and len(streamer_list) > 1:
+        section_title("스트리머별 인기 키워드")
+
+        time_where = []
+        time_params = []
+        if time_interval:
+            time_where.append("window_start >= NOW() - INTERVAL %s")
+            time_params.append(time_interval)
+        if selected_pos:
+            time_where.append("pos = %s")
+            time_params.append(selected_pos)
+        tw_sql = "WHERE " + " AND ".join(time_where) if time_where else ""
+
+        df_by_streamer = query_df(_conn, f"""
+            SELECT streamer, keyword, SUM(count) as total
+            FROM keyword_counts {tw_sql}
+            GROUP BY streamer, keyword
+            ORDER BY streamer, total DESC
+        """, time_params or None)
+
+        if not df_by_streamer.empty:
+            top_per_streamer = df_by_streamer.groupby("streamer").head(10)
+            pivot_streamer = top_per_streamer.pivot_table(
+                index="keyword", columns="streamer", values="total", fill_value=0, aggfunc="sum"
+            )
+            st.dataframe(pivot_streamer, width="stretch")
+
+    _conn.close()
+
+
+render_keywords()
+
+conn.close()

--- a/modules/postgresql/schema.py
+++ b/modules/postgresql/schema.py
@@ -37,6 +37,30 @@ CREATE TABLE IF NOT EXISTS streamers (
     is_active       BOOLEAN DEFAULT FALSE,
     created_at      TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS keyword_counts (
+    id              SERIAL PRIMARY KEY,
+    window_start    TIMESTAMP NOT NULL,
+    streamer        TEXT NOT NULL,
+    keyword         TEXT NOT NULL,
+    pos             TEXT NOT NULL,
+    count           INTEGER NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP DEFAULT NOW(),
+    UNIQUE (window_start, streamer, keyword, pos)
+);
+
+CREATE INDEX IF NOT EXISTS idx_keyword_counts_window ON keyword_counts (window_start);
+CREATE INDEX IF NOT EXISTS idx_keyword_counts_streamer ON keyword_counts (streamer);
+CREATE INDEX IF NOT EXISTS idx_keyword_counts_keyword ON keyword_counts (keyword);
+
+CREATE TABLE IF NOT EXISTS keyword_settings (
+    key     TEXT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+INSERT INTO keyword_settings (key, value)
+VALUES ('chat_threshold', '500'), ('last_analyzed_at', '1970-01-01T00:00:00')
+ON CONFLICT (key) DO NOTHING;
 """
 
 def init_schema(connection):

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -7,7 +7,7 @@ streamers 테이블의 is_active 플래그를 폴링하여
 import threading
 import time
 
-from components import streaming_check, producer, consumer
+from components import streaming_check, producer, consumer, keyword_analyzer
 from modules.postgresql import get_connection
 from modules.postgresql.schema import init_schema
 
@@ -55,6 +55,11 @@ def main():
         t = threading.Thread(target=consumer.run, args=(topic,), daemon=True)
         t.start()
         print(f"[Orchestrator] Consumer 시작: {topic}")
+
+    # 키워드 배치 분석 스레드
+    t = threading.Thread(target=keyword_analyzer.run, daemon=True)
+    t.start()
+    print("[Orchestrator] Keyword Analyzer 시작")
 
     active_crawlers: dict[str, threading.Thread] = {}
     shutdown_events: dict[str, threading.Event] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "streamlit>=1.45.0",
     "psutil>=7.0.0",
+    "kiwipiepy>=0.18",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "kafka-python" },
+    { name = "kiwipiepy" },
     { name = "psutil" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -144,6 +145,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "kafka-python", specifier = ">=2.2.13" },
+    { name = "kiwipiepy", specifier = ">=0.18" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2.11.5" },
@@ -258,6 +260,35 @@ sdist = { url = "https://files.pythonhosted.org/packages/27/5c/d3b6d93ed625d2cb0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/db/694fd552295ed091e7418d02b6268ee36092d4c93211136c448fe061fe32/kafka_python-2.3.0-py2.py3-none-any.whl", hash = "sha256:831ba6dff28144d0f1145c874d391f3ebb3c2c3e940cc78d74e83f0183497c98", size = 326260, upload_time = "2025-11-21T00:47:32.561Z" },
 ]
+
+[[package]]
+name = "kiwipiepy"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kiwipiepy-model" },
+    { name = "numpy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/e1/e407471d8306e8a43fefff54e5bcd51feb77cc28cf4033be8ad0d5f6fadc/kiwipiepy-0.22.2.tar.gz", hash = "sha256:4a8a4b17b6b229a7e315af1e45727aa21a73ee529a9471161558bf05674b9658", size = 2429596, upload_time = "2025-12-15T15:13:24.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/3e/b0a3119c6585e5ca2de3c944837a05d03ddb26d7aaa06a7a5a5c761d94f6/kiwipiepy-0.22.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6309f30bddb0e71bb863c90d640f7e3fe030faa0b3f87bdf51e63621a90eada", size = 8848123, upload_time = "2025-12-15T15:18:29.926Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f9/eabc35d497e80831b59d1c49d2e0eb65a83e36f194bca75f83b4b8340c50/kiwipiepy-0.22.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:230b00414843b9c03d542bb46122918d969aa0f1c49fee633b6e103643c5eead", size = 3516006, upload_time = "2025-12-15T15:15:43.663Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/00/dd24f2e3b8d7dfb984dab5cec4f2f2fdbf5ead1d1921c4eca14da02c4098/kiwipiepy-0.22.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ed83e7d90cc11a29b49d1c9be602f84562996e2b7b6de77de65618935b1a71f5", size = 3027558, upload_time = "2025-12-15T15:19:59.277Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0e/e06c6d08aa6e56cf7b4650bd07389b56c1ec1a011896d39e07e1576fd2ee/kiwipiepy-0.22.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:650539424681bdef0cec89c4ed40f3b1fc880e036edaf890b0fa3a36bfade38c", size = 5915096, upload_time = "2025-12-15T15:38:27.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2c/87341a3391b065151b7a9cbcfd6ec34c345d1624cfb01ac1e0220e94a756/kiwipiepy-0.22.2-cp314-cp314t-win_amd64.whl", hash = "sha256:db7d641f07d4f49b062a475eeb00b4cdfb379ba77f611a947ae68f93ce425615", size = 2592179, upload_time = "2025-12-15T15:26:31.588Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/84/4d59d0538507399f973e449a1ad2b39da0cc998f16b2e986ce6daf7128fb/kiwipiepy-0.22.2-cp39-abi3-macosx_10_14_x86_64.whl", hash = "sha256:3db88b1756010ce6e192f047ec5b2ed9711c3ab3390e19d5fa590542c6cd39e6", size = 8840234, upload_time = "2025-12-15T15:27:28.742Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ee/2cbb1dd9cf5bf26c5620ca325fcef27a7b20772fc3b2374fab80be4ef7b2/kiwipiepy-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc0f54282b6bb64046aa94e1f8dc66f99f67fb626a0a283dcba24981e607852e", size = 3507298, upload_time = "2025-12-15T15:14:19.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/84/ca2733d860b6c973b8585f419132ec557c8e3801e11b5fe6f11958be6cb7/kiwipiepy-0.22.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f71dcc85f870a82c6290a5824cee2f744df2cd05ad7a5e4cbd40184f69bb284e", size = 3025751, upload_time = "2025-12-15T15:20:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/a6/71fe6cbcdc306748c23a8da54525055adab994167d18fdf19acb92816ece/kiwipiepy-0.22.2-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:628e468d55acec204b71720fc6f9a29994edbae0512e31be0a46e9efa9eb56bc", size = 5914603, upload_time = "2025-12-15T15:38:28.534Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d9/be3009a2fd00b4892566f9139bb161e267c943811345524f59408ee8f373/kiwipiepy-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:cadbbbb877e381e39d2d4efbdabc053458e0e29756ff0a2b41cc611ff0f2f1af", size = 2514919, upload_time = "2025-12-15T15:27:51.881Z" },
+]
+
+[[package]]
+name = "kiwipiepy-model"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/a1/f6d1113784dc3669d1ac4e4be1584af206a1aa7daa952a8805213324256e/kiwipiepy_model-0.22.1.tar.gz", hash = "sha256:c2359920c9f6d66b131452c905a3c8792305f9bdee6cedbe6088d0430653fd8b", size = 79496954, upload_time = "2025-12-15T15:38:39.331Z" }
 
 [[package]]
 name = "markupsafe"
@@ -1034,6 +1065,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload_time = "2026-03-10T21:30:57.142Z" },
     { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload_time = "2026-03-10T21:30:58.857Z" },
     { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload_time = "2026-03-10T21:31:00.43Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload_time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload_time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **kiwipiepy 기반 키워드 배치 분석기** 추가 — 미분석 채팅이 임계값 이상 쌓이면 자동 분석 실행 (Kafka consumer 방식 → DB 폴링 방식으로 자원 절약)
- **키워드 분석 대시보드 페이지** 추가 — 인기 키워드 TOP 20, 트렌드 차트, 품사별 분포, 이모티콘 렌더링, 문장 단위 채팅 뷰, 분석 임계값 설정 UI
- Streamlit deprecated `use_container_width` → `width="stretch"` 마이그레이션

## 주요 변경
| 파일 | 내용 |
|------|------|
| `pyproject.toml` / `uv.lock` | kiwipiepy 의존성 추가 |
| `modules/postgresql/schema.py` | `keyword_counts`, `keyword_settings` 테이블 추가 |
| `components/keyword_analyzer.py` | DB 폴링 배치 분석기 (단일 키워드 + 바이그램 추출) |
| `orchestrator.py` | keyword_analyzer 스레드 추가 |
| `dashboard/pages/5_keywords.py` | 키워드 분석 대시보드 페이지 |
| `dashboard/app.py` | 키워드 분석 바로가기 추가 |
| `dashboard/pages/{1,2,3}_*.py` | deprecated param 마이그레이션 |

## 데이터 흐름
```
Producer → Kafka (chat) → Consumer → chat_messages (PostgreSQL)
                                          ↓
                              KeywordAnalyzer (임계값 초과 시 배치 분석)
                                          ↓
                                    keyword_counts (PostgreSQL)
                                          ↓
                                    Dashboard (시각화)
```

## 배포 시 필요 작업
```bash
# 기존 DB에 새 테이블 적용 (컨테이너 재빌드 시 자동 실행되지만, 기존 키 정리 필요)
docker compose -f docker/docker-compose.yaml exec postgres-server psql -U postgres -d chzzk -c "
DELETE FROM keyword_settings WHERE key = 'last_analyzed_id';
"

# 컨테이너 재빌드
docker compose -f docker/docker-compose.yaml up -d --build chzzk-analytics dashboard

# (선택) 사용하지 않는 Kafka consumer group 삭제
docker compose -f docker/docker-compose.yaml exec broker kafka-consumer-groups \
  --bootstrap-server broker:29092 --delete --group keyword-analyzer
```

## Test plan
- [x] `uv sync` → kiwipiepy 설치 확인
- [x] `uv run ruff check .` 린트 통과
- [x] orchestrator 실행 → `[Orchestrator] Keyword Analyzer 시작` 로그 확인
- [x] 임계값 초과 후 `SELECT * FROM keyword_counts ORDER BY count DESC LIMIT 20;` 집계 확인
- [x] 대시보드 키워드 분석 페이지 정상 렌더링 확인
- [x] 임계값 변경 UI 동작 확인
- [x] 미분석 채팅 진행률 5초 자동 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)